### PR TITLE
added label parksmap-backend to route

### DIFF
--- a/ose3/application-template-eap.json
+++ b/ose3/application-template-eap.json
@@ -607,7 +607,8 @@
       "metadata": {
         "name": "${APPLICATION_NAME}",
         "labels": {
-          "component": "${APPLICATION_NAME}"
+          "component": "${APPLICATION_NAME}",
+          "type": "parksmap-backend"          
         }
       },
       "spec": {

--- a/ose3/application-template-wildfly.json
+++ b/ose3/application-template-wildfly.json
@@ -584,7 +584,8 @@
       "metadata": {
         "name": "${APPLICATION_NAME}",
         "labels": {
-          "component": "${APPLICATION_NAME}"
+          "component": "${APPLICATION_NAME}",
+          "type": "parksmap-backend"
         }
       },
       "spec": {


### PR DESCRIPTION
The parksmap web app in the roadshow queries the routes for label "type=parksmap-backend".  Without this label it won't pick up the mlbparks data.