### PR TITLE
Update jboss-eap imagestream to later version

### DIFF
--- a/ose3/application-template-eap.json
+++ b/ose3/application-template-eap.json
@@ -382,7 +382,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "openshift",
-              "name": "jboss-eap70-openshift:1.6"
+              "name": "jboss-eap72-openjdk11-openshift-rhel8:latest"
             },
             "env": [
               {


### PR DESCRIPTION
Update the imagestream to jboss-eap72-openjdk11-openshift-rhel8:latest 
can probably update even later, however for now this works.